### PR TITLE
Support for Unicode Roman Numerals (e.g. Ⅳ, Ⅷ, etc.)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ keywords = ["roman", "numeral", "septem"]
 
 [badges]
 travis-ci = { repository = "mipli/septem" }
+
+[features]
+default = []
+archaic = []

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ including **Unicode Number Forms** and optional **archaic Roman numerals**.
 
 ### Basic Example
 
+Parsing from string is provided using Rust's `FromStr` trait.
+
 ```rust
 extern crate septem;
 use septem::{Roman};
@@ -20,6 +22,14 @@ let sept: Roman = "vii".parse().unwrap();
 assert_eq!(7, *sept);
 assert_eq!("VII", sept.to_string());
 assert_eq!("vii", sept.to_lowercase());
+
+// unicode
+let sept: Roman = "Ⅶ".parse().unwrap();
+assert_eq!(7, *sept);
+
+// combination with unicode 
+let septendecim: Roman = "XⅦ".parse().unwrap();
+assert_eq!(17, *septendecim);
 ```
 
 The `use septem::prelude::*` is required to support the `std::str::{FromStr}` trait and the `Roman::from_str` function.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 # Septem
 
 A library for parsing and working with Roman numerals.
-
 Supports easy conversion from strings or numbers to roman numerals, and easy conversion back again.
-
+including **Unicode Number Forms** and optional **archaic Roman numerals**.
 
 ## Usage
+
+### Basic Example
 
 ```rust
 extern crate septem;
@@ -33,29 +34,50 @@ assert_eq!(532, *roman);
 
 ### To Roman Numerals
 
-Parsing from string is provided using Rust's `FromStr` trait.
+Convert integers into Roman numerals using either the `From` or `from_int` method:
 
 ```rust
-let num: Roman = "XLII".parse().unwrap();
-```
+use septem::Roman;
 
-Parsing from an integer is done using `Roman::from`.
-
-```rust
 let num: Roman = Roman::from(42).unwrap();
+println!("{}", num); // "XLII"
 ```
+
+Or directly with digits:
+
+```rust
+use septem::Digit;
+
+let digits = Digit::from_int(1994u32).unwrap();
+assert_eq!(
+    digits,
+    vec![
+        Digit::M, Digit::C, Digit::M, // 1900
+        Digit::X, Digit::C,           // 90
+        Digit::I, Digit::V            // 4
+    ]
+);
+```
+
+---
 
 ### From Roman Numerals
 
-A string representation of the roman numeral can be gotten using Rust's `Display` trait.
+A Roman numeral can be converted back to a number easily:
 
 ```rust
-println!("Roman number: {}", Roman::from(42).unwrap());
+use septem::Roman;
+
+let roman = Roman::from(42).unwrap();
+assert_eq!(42, *roman);
 ```
-There are also functions to get the string without going through the formatter; `to_string`, `to_lowercase` and `to_uppercase`. 
+
+String conversions are handled by `Display`, `to_string`, or `to_lowercase`:
 
 ```rust
-let dis = Roman::from(42).unwrap().to_string();
+let roman = Roman::from(42).unwrap();
+println!("Roman: {}", roman);            // "XLII"
+println!("Lowercase: {}", roman.to_lowercase()); // "xlii"
 ```
 
 The numerical value of the roman numeral is available through Rust's `Deref` trait.
@@ -65,16 +87,67 @@ let roman = Roman::from(42).unwrap();
 assert_eq!(42, *roman);
 ```
 
-### Digits
+---
 
-If you need to work with the digits that make up the Roman numeral you can get those with the `to_digits` function.
+### Unicode Support
+
+`septem` automatically supports **Unicode Number Forms** (U+2160–U+217F):
+
 ```rust
-let roman = Roman::from(42).unwrap();
-roman.to_digits().iter().for_each(|i| {
-  println!("digit: {}", i);
-});
+use septem::Digit;
+
+assert_eq!(Digit::from_char('Ⅷ').unwrap(), vec![Digit::V, Digit::I, Digit::I, Digit::I]);
+assert_eq!(Digit::from_char('ⅳ').unwrap(), vec![Digit::I, Digit::V]);
 ```
 
+---
+
+### Optional Archaic Numerals
+
+Enable ancient forms by turning on the `archaic` feature:
+
+```bash
+cargo add septem --features archaic
+```
+
+These include large-value symbols:
+
+| Character | Value   | Name               |
+| --------- | ------- | ------------------ |
+| ↀ         | 1000    | One Thousand (old) |
+| ↁ         | 5000    | Five Thousand      |
+| ↂ         | 10 000  | Ten Thousand       |
+| ↇ         | 50 000  | Fifty Thousand     |
+| ↈ         | 100 000 | Hundred Thousand   |
+
+Example:
+
+```rust
+#[cfg(feature = "archaic")]
+{
+    use septem::Digit;
+
+    assert_eq!(Digit::from_char('ↀ').unwrap(), vec![Digit::OneThousandOld]);
+    assert_eq!(Digit::from_char('ↁ').unwrap(), vec![Digit::FiveThousand]);
+    assert_eq!(Digit::from_char('ↂ').unwrap(), vec![Digit::TenThousand]);
+    assert_eq!(Digit::from_char('ↇ').unwrap(), vec![Digit::FiftyThousand]);
+    assert_eq!(Digit::from_char('ↈ').unwrap(), vec![Digit::HundredThousand]);
+}
+```
+
+---
+
+### Working with Digits
+
+You can access the component digits of a Roman numeral:
+
+```rust
+let roman = Roman::from(42).unwrap();
+for d in roman.to_digits() {
+    println!("Digit: {}", d);
+}
+
+```
 ## Performance
 
 Benchmarks for converting from a Roman numeral in string form to an integer, and the other way around are supplied. Testing against a few other Roman numeral libraries shows that this crate is performing on the same levels, or slightly faster than the alternatives. It is after all very important to have fast roman numeral conversion, can't have such an important part of a program be slow!

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result};
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::ops::{self};
+use std::ops;
 
 /// Representation of a roman digit
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result};
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::ops;
+use std::ops::{self};
 
 /// Representation of a roman digit
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -12,62 +12,287 @@ pub enum Digit {
     C,
     D,
     M,
+
+    #[cfg(feature = "archaic")]
+    OneThousandOld, // ↀ
+    #[cfg(feature = "archaic")]
+    FiveThousand, // ↁ
+    #[cfg(feature = "archaic")]
+    TenThousand, // ↂ
+    #[cfg(feature = "archaic")]
+    FiftyThousand, // ↇ
+    #[cfg(feature = "archaic")]
+    HundredThousand, // ↈ
 }
 
 impl Digit {
-    /// Tries to converts a value that implements `Into<u32>` into a single roman digit
+    /// Converts any positive integer into a vector of Roman digits.
     ///
     /// # Examples
     /// ```rust
     /// # use septem::prelude::*;
     /// # use septem::*;
     ///
-    /// let v: Digit = Digit::from_int(5u8).unwrap();
-    /// assert_eq!(Digit::V, v);
+    /// let three = Digit::from_int(3u8).unwrap();
+    /// assert_eq!(three, vec![Digit::I, Digit::I, Digit::I]);
+    ///
+    /// let eight = Digit::from_int(8u8).unwrap();
+    /// assert_eq!(eight, vec![Digit::V, Digit::I, Digit::I, Digit::I]);
+    ///
+    /// let nine = Digit::from_int(9u8).unwrap();
+    /// assert_eq!(nine, vec![Digit::I, Digit::X]);
+    ///
+    /// let nineteen_ninety_four = Digit::from_int(1994u32).unwrap();
+    /// assert_eq!(
+    ///     nineteen_ninety_four,
+    ///     vec![
+    ///         Digit::M, Digit::C, Digit::M, // 1900
+    ///         Digit::X, Digit::C,           // 90
+    ///         Digit::I, Digit::V            // 4
+    ///     ]
+    /// );
+    ///
+    /// assert!(Digit::from_int(0u8).is_err(), "zero is invalid");
     /// ```
     ///
-    /// Returns `Digit` , or an `septem::Error`
-    pub fn from_int<T: Into<u32>>(num: T) -> Result<Digit> {
-        let num: u32 = num.into();
-        use self::Digit::*;
-        match num {
-            1 => Ok(I),
-            5 => Ok(V),
-            10 => Ok(X),
-            50 => Ok(L),
-            100 => Ok(C),
-            500 => Ok(D),
-            1000 => Ok(M),
-            _ => Err(Error::InvalidNumber(num)),
+    /// Returns `Vec<Digit>`, or an `septem::Error` if the number is zero or too large.
+    pub fn from_int<T>(num: T) -> Result<Vec<Digit>>
+    where
+        T: Into<u32> + Copy + PartialOrd + From<u8>,
+    {
+        let mut n: u32 = num.into();
+        if n == 0 {
+            return Err(Error::InvalidNumber(n));
         }
+
+        use Digit::*;
+
+        const TABLE: &[(u32, &[Digit])] = &[
+            (1000, &[M]),
+            (900, &[C, M]),
+            (500, &[D]),
+            (400, &[C, D]),
+            (100, &[C]),
+            (90, &[X, C]),
+            (50, &[L]),
+            (40, &[X, L]),
+            (10, &[X]),
+            (9, &[I, X]),
+            (5, &[V]),
+            (4, &[I, V]),
+            (1, &[I]),
+        ];
+
+        let mut result = Vec::with_capacity(15);
+
+        for &(value, digits) in TABLE {
+            if n == 0 {
+                break;
+            }
+
+            let count = n / value;
+            match digits {
+                &[a] => result.extend(std::iter::repeat(a).take(count as usize)),
+                &[a, b] => (0..count).for_each(|_| {
+                    result.push(a);
+                    result.push(b);
+                }),
+                _ => unreachable!(),
+            }
+
+            n %= value;
+        }
+
+        Ok(result)
+    }
+
+    /// Returns the numeric value of this Roman digit as any type that implements `From<u32>`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use septem::prelude::*;
+    /// # use septem::*;
+    ///
+    /// let v: u32 = Digit::V.value();
+    /// let x: u64 = Digit::X.value();
+    /// let f: f64 = Digit::L.value();
+    ///
+    /// assert_eq!(v, 5);
+    /// assert_eq!(x, 10);
+    /// assert_eq!(f, 50.0);
+    /// ```
+    pub fn value<T>(&self) -> T
+    where
+        T: From<u32>,
+    {
+        let v = match self {
+            Digit::I => 1,
+            Digit::V => 5,
+            Digit::X => 10,
+            Digit::L => 50,
+            Digit::C => 100,
+            Digit::D => 500,
+            Digit::M => 1000,
+
+            #[cfg(feature = "archaic")]
+            Digit::OneThousandOld => 1000,
+            #[cfg(feature = "archaic")]
+            Digit::FiveThousand => 5000,
+            #[cfg(feature = "archaic")]
+            Digit::TenThousand => 10000,
+            #[cfg(feature = "archaic")]
+            Digit::FiftyThousand => 50000,
+            #[cfg(feature = "archaic")]
+            Digit::HundredThousand => 100000,
+        };
+        T::from(v)
+    }
+
+    /// Computes the numeric value of a Roman numeral sequence (e.g. `XIV` → `14`).
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use septem::prelude::*;
+    /// # use septem::*;
+    ///
+    /// let digits = vec![Digit::X, Digit::I, Digit::I];
+    /// assert_eq!(Digit::value_of::<u32>(&digits), 12);
+    ///
+    /// let digits = vec![Digit::X, Digit::I, Digit::V];
+    /// assert_eq!(Digit::value_of::<u32>(&digits), 14);
+    ///
+    /// let digits = vec![Digit::I, Digit::X];
+    /// assert_eq!(Digit::value_of::<u64>(&digits), 9);
+    /// ```
+    pub fn value_of<T>(digits: &[Digit]) -> T
+    where
+        T: From<u32>
+            + Copy
+            + std::ops::Add<Output = T>
+            + std::ops::Sub<Output = T>
+            + PartialOrd
+            + Default,
+    {
+        let mut total = T::default();
+        let mut i = 0;
+
+        while i < digits.len() {
+            let curr = digits[i].value::<T>();
+            if i + 1 < digits.len() {
+                let next = digits[i + 1].value::<T>();
+                if curr < next {
+                    total = total + (next - curr);
+                    i += 2;
+                    continue;
+                }
+            }
+            total = total + curr;
+            i += 1;
+        }
+
+        total
     }
 }
 
 impl Digit {
-    /// Tries to converts a char into a single roman digit
+    /// Tries to convert a character into a single Roman digit.
+    ///
+    /// Supports:
+    /// - ASCII letters: `'I', 'V', 'X', 'L', 'C', 'D', 'M'` (case-insensitive)
+    /// - Unicode Number Forms: `'Ⅰ'..'Ⅿ'` (U+2160–U+216F) and `'ⅰ'..'ⅿ'` (U+2170–U+217F)
+    /// - (Optional) Archaic forms `'ↀ'..'ↈ'` when `feature = "archaic"` is enabled
+    ///
+    /// Returns a vector of `Digit` representing the decomposed Roman numeral if applicable.
     ///
     /// # Examples
     /// ```rust
     /// # use septem::prelude::*;
     /// # use septem::*;
     ///
-    /// let v: Digit = Digit::from_char('v').unwrap();
-    /// assert_eq!(Digit::V, v);
+    /// // ASCII lowercase
+    /// let v = Digit::from_char('v').unwrap();
+    /// assert_eq!(v, vec![Digit::V]);
+    ///
+    /// // ASCII uppercase
+    /// let x = Digit::from_char('X').unwrap();
+    /// assert_eq!(x, vec![Digit::X]);
+    ///
+    /// // Unicode uppercase
+    /// let viii = Digit::from_char('Ⅷ').unwrap();
+    /// assert_eq!(viii, vec![Digit::V, Digit::I, Digit::I, Digit::I]);
+    ///
+    /// // Unicode lowercase
+    /// let iv = Digit::from_char('ⅳ').unwrap();
+    /// assert_eq!(iv, vec![Digit::I, Digit::V]);
+    ///
+    /// // Invalid character
+    /// let err = Digit::from_char('A');
+    /// assert!(err.is_err());
     /// ```
     ///
-    /// Returns `Digit` , or an `septem::Error`
-    pub fn from_char(c: char) -> Result<Digit> {
+    /// # Archaic Numerals
+    /// ```rust
+    /// # #[cfg(feature = "archaic")]
+    /// # {
+    /// # use septem::prelude::*;
+    /// # use septem::*;
+    ///
+    /// let thousand = Digit::from_char('ↀ').unwrap();
+    /// assert_eq!(thousand, vec![Digit::OneThousandOld]);
+    ///
+    /// let five_thousand = Digit::from_char('ↁ').unwrap();
+    /// assert_eq!(five_thousand, vec![Digit::FiveThousand]);
+    ///
+    /// let ten_thousand = Digit::from_char('ↂ').unwrap();
+    /// assert_eq!(ten_thousand, vec![Digit::TenThousand]);
+    ///
+    /// let fifty_thousand = Digit::from_char('ↇ').unwrap();
+    /// assert_eq!(fifty_thousand, vec![Digit::FiftyThousand]);
+    ///
+    /// let hundred_thousand = Digit::from_char('ↈ').unwrap();
+    /// assert_eq!(hundred_thousand, vec![Digit::HundredThousand]);
+    /// # }
+    /// ```
+    ///
+    /// Returns `Vec<Digit>` or an [`septem::Error::InvalidDigit`].
+    pub fn from_char(c: char) -> Result<Vec<Digit>> {
         use self::Digit::*;
-        match c.to_uppercase().next() {
-            Some('I') => Ok(I),
-            Some('V') => Ok(V),
-            Some('X') => Ok(X),
-            Some('L') => Ok(L),
-            Some('C') => Ok(C),
-            Some('D') => Ok(D),
-            Some('M') => Ok(M),
-            _ => Err(Error::InvalidDigit(c)),
-        }
+
+        let result = match c {
+            // Single Roman numerals (ASCII + Unicode uppercase/lowercase)
+            'Ⅰ' | 'ⅰ' | 'I' | 'i' => vec![I],
+            'Ⅱ' | 'ⅱ' => vec![I, I],
+            'Ⅲ' | 'ⅲ' => vec![I, I, I],
+            'Ⅳ' | 'ⅳ' => vec![I, V],
+            'Ⅴ' | 'ⅴ' | 'V' | 'v' => vec![V],
+            'Ⅵ' | 'ⅵ' => vec![V, I],
+            'Ⅶ' | 'ⅶ' => vec![V, I, I],
+            'Ⅷ' | 'ⅷ' => vec![V, I, I, I],
+            'Ⅸ' | 'ⅸ' => vec![I, X],
+            'Ⅹ' | 'ⅹ' | 'X' | 'x' => vec![X],
+            'Ⅺ' | 'ⅺ' => vec![X, I],
+            'Ⅻ' | 'ⅻ' => vec![X, I, I],
+            'Ⅼ' | 'ⅼ' | 'L' | 'l' => vec![L],
+            'Ⅽ' | 'ⅽ' | 'C' | 'c' => vec![C],
+            'Ⅾ' | 'ⅾ' | 'D' | 'd' => vec![D],
+            'Ⅿ' | 'ⅿ' | 'M' | 'm' => vec![M],
+
+            // Optional archaic numerals
+            #[cfg(feature = "archaic")]
+            'ↀ' => vec![OneThousandOld],
+            #[cfg(feature = "archaic")]
+            'ↁ' => vec![FiveThousand],
+            #[cfg(feature = "archaic")]
+            'ↂ' => vec![TenThousand],
+            #[cfg(feature = "archaic")]
+            'ↇ' => vec![FiftyThousand],
+            #[cfg(feature = "archaic")]
+            'ↈ' => vec![HundredThousand],
+
+            _ => return Err(Error::InvalidDigit(c)),
+        };
+
+        Ok(result)
     }
 
     /// Tries to converts a byte into a single roman digit

--- a/tests/digit.rs
+++ b/tests/digit.rs
@@ -7,13 +7,13 @@ mod tests {
     fn from_int_valid() {
         let n = Digit::from_int(5u8);
         assert!(n.is_ok());
-        assert_eq!(Digit::V, n.unwrap());
+        assert_eq!(vec![Digit::V], n.unwrap());
     }
 
     #[test]
     fn from_int_invalid() {
-        match Digit::from_int(3u32) {
-            Err(Error::InvalidNumber(num)) => assert_eq!(3, num),
+        match Digit::from_int(0u32) {
+            Err(Error::InvalidNumber(num)) => assert_eq!(0, num),
             _ => assert!(false),
         }
     }


### PR DESCRIPTION
Hi!

As what we discussed in [this discussion](https://github.com/mipli/septem/issues/2) I implemented:
- Unicode support for `fn from_char(c: char) -> Result<Vec<Digit>>`.
- Split the feature called `archaic` because characters like `ↈ` is rarely used.
- Add more doc tests and change 2 of them mostly because we now return `Vec<Digit>`.

As suggestion:
> Would have to look at adding similar support to the Roman conversions as well

Now `Roman::from_str` could parse mixing string like `XⅦ`. However, because Unicode characters like `Ⅶ` is more than 1 byte using `from_byte` have to become `from_char` and result of map become 2D Vec instead. As a result, it ~5 times slower than the original (tested on `mmmdcccxciii` case)  and we have to change most of the code in `Roman::from_str`.

*I tried to use both `collect.iter.flatten` and `for` with `extend` to avoid changing your code. But with this, performance drop even more (~7-10 times slower). This is all I could do to preserve your logic, please let me know if you want to revert what I changed in Roman*